### PR TITLE
Make error formatting consistent

### DIFF
--- a/src/bootstrap-stubs/views/auth/passwords/email.blade.php
+++ b/src/bootstrap-stubs/views/auth/passwords/email.blade.php
@@ -16,16 +16,16 @@
                     <form role="form" method="POST" action="{{ url('/password/email') }}">
                         {!! csrf_field() !!}
 
-                        <div class="form-group row{{ $errors->has('email') ? ' has-error' : '' }}">
+                        <div class="form-group row">
                             <label class="col-md-4 col-form-label text-right">E-Mail Address</label>
 
                             <div class="col-md-6">
-                                <input type="email" class="form-control" name="email" value="{{ old('email') }}">
+                                <input type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}">
 
                                 @if ($errors->has('email'))
-                                    <span class="form-text text-muted">
-                                    <strong>{{ $errors->first('email') }}</strong>
-                                </span>
+                                    <div class="invalid-feedback">
+                                        <strong>{{ $errors->first('email') }}</strong>
+                                    </div>
                                 @endif
                             </div>
                         </div>

--- a/src/bootstrap-stubs/views/auth/register.blade.php
+++ b/src/bootstrap-stubs/views/auth/register.blade.php
@@ -23,7 +23,7 @@
                                 >
                                 @if ($errors->has('name'))
                                     <div class="invalid-feedback">
-                                        {{ $errors->first('name') }}
+                                        <strong>{{ $errors->first('name') }}</strong>
                                     </div>
                                 @endif
                             </div>
@@ -43,7 +43,7 @@
 
                                 @if ($errors->has('email'))
                                     <div class="invalid-feedback">
-                                        {{ $errors->first('email') }}
+                                        <strong>{{ $errors->first('email') }}</strong>
                                     </div>
                                 @endif
                             </div>
@@ -61,7 +61,7 @@
                                 >
                                 @if ($errors->has('password'))
                                     <div class="invalid-feedback">
-                                        {{ $errors->first('password') }}
+                                        <strong>{{ $errors->first('password') }}</strong>
                                     </div>
                                 @endif
                             </div>
@@ -79,7 +79,7 @@
                                 >
                                 @if ($errors->has('password_confirmation'))
                                     <div class="invalid-feedback">
-                                        {{ $errors->first('password_confirmation') }}
+                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
                                     </div>
                                 @endif
                             </div>


### PR DESCRIPTION
Added `<strong>` around error messages. Could go the other way and remove them elsewhere.